### PR TITLE
Show shelf expire time for holds in PINES

### DIFF
--- a/pines_app/src/main/res/values/ou.xml
+++ b/pines_app/src/main/res/values/ou.xml
@@ -25,7 +25,7 @@
     <bool name="ou_enable_phone_notification">true</bool>
     <bool name="ou_enable_hold_pickup_location">true</bool>
     <bool name="ou_enable_hold_queue_position">false</bool>
-    <bool name="ou_enable_hold_shelf_expiration">false</bool>
+    <bool name="ou_enable_hold_shelf_expiration">true</bool>
     <bool name="ou_enable_messages">true</bool>
     <bool name="ou_enable_part_holds">true</bool>
     <bool name="ou_enable_title_hold_on_item_with_parts">false</bool>

--- a/pines_app/src/main/res/values/strings.xml
+++ b/pines_app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="button_pay_fines">Pay all charges</string>
     <string name="balance_owed">Charges</string>
     <string name="hold_status_available">Ready for pickup at %1$s</string>
+    <string name="hold_status_expires">Pick up by %1$s</string>
     <string name="title_open_full_catalog">Full Catalog</string>
     <string name="title_library_locator">Library Locator</string>
     <string name="title_galileo">GALILEO Virtual Library</string>


### PR DESCRIPTION
Shows the date a hold will expire on the shelf in the PINES app, and changes the wording a tad.